### PR TITLE
Fixed Dockerfile for preferences

### DIFF
--- a/customer/java/microprofile/src/main/java/com/redhat/developer/demos/customer/rest/CustomerEndpoint.java
+++ b/customer/java/microprofile/src/main/java/com/redhat/developer/demos/customer/rest/CustomerEndpoint.java
@@ -21,7 +21,7 @@ public class CustomerEndpoint {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
-    @ConfigProperty(name = "preferences.api.url", defaultValue = "http://preferences:8080")
+    @ConfigProperty(name = "preferences.api.url", defaultValue = "http://preference:8080")
     private String remoteURL;
 
 

--- a/customer/java/springboot/pom.xml
+++ b/customer/java/springboot/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.uber.jaeger</groupId>
             <artifactId>jaeger-tracerresolver</artifactId>
-            <version>0.25.0</version>
+            <version>0.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/customer/java/springboot/src/main/java/com/redhat/developer/demos/customer/CustomerController.java
+++ b/customer/java/springboot/src/main/java/com/redhat/developer/demos/customer/CustomerController.java
@@ -20,7 +20,7 @@ public class CustomerController {
 
     private final RestTemplate restTemplate;
 
-    @Value("${preferences.api.url:http://preferences:8080}")
+    @Value("${preferences.api.url:http://preference:8080}")
     private String remoteURL;
 
     public CustomerController(RestTemplate restTemplate) {

--- a/preference/java/springboot/Dockerfile
+++ b/preference/java/springboot/Dockerfile
@@ -1,7 +1,9 @@
 FROM fabric8/java-jboss-openjdk8-jdk:1.3.1
 ENV JAVA_APP_DIR=/deployments
 ENV JAEGER_SERVICE_NAME=preference \
-  JAEGER_SAMPLER_TYPE=const\
+  JAEGER_ENDPOINT=http://jaeger-collector.istio-system.svc:14268/api/traces \
+  JAEGER_PROPAGATION=b3 \
+  JAEGER_SAMPLER_TYPE=const \
   JAEGER_SAMPLER_PARAM=1
 EXPOSE 8080 8778 9779
 COPY target/preference.jar /deployments/

--- a/preference/java/springboot/pom.xml
+++ b/preference/java/springboot/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.uber.jaeger</groupId>
             <artifactId>jaeger-core</artifactId>
-            <version>0.25.0</version>
+            <version>0.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/preference/java/springboot/readme.md
+++ b/preference/java/springboot/readme.md
@@ -11,7 +11,8 @@ Running on the local machine
 To run this service for development purposes on your own machine, execute:
 
 ```bash
-mvn spring-boot:run \
+JAEGER_SERVICE_NAME=preference mvn \
+  spring-boot:run \
   -Drun.arguments="--spring.config.location=src/main/resources/application-local.properties"
 ```
 


### PR DESCRIPTION
The `Dockerfile` for `preferences` was missing the `B3` propagation codec, causing the trace to break in the `preferences` service:

![](https://screenshotscdn.firefoxusercontent.com/images/8cc14f0b-7418-470f-ac81-b88c2296a381.png)

With this fix, it's appropriately shown as a single trace:

![](https://screenshotscdn.firefoxusercontent.com/images/d87e0445-91b4-4d56-9082-ae730201aece.png)