### PR TITLE
Adding JAEGER_SERVICE_NAME for OpenShift S2I and fix preference service name, otherwise it does not deploy/run

### DIFF
--- a/docs/2deploy-microservices.adoc
+++ b/docs/2deploy-microservices.adoc
@@ -46,7 +46,7 @@ GolangVersion: go1.10.1
 BuildStatus: Clean
 ----
 
-==== Customer build using Docker daemon 
+==== Customer build using Docker daemon
 
 NOTE: Your very first Docker build will take a bit of time as it downloads all the layers. Subsequent rebuilds of the Docker image, updating only the microservice layer will be very fast.
 
@@ -160,7 +160,7 @@ kubectl create -f ../../kubernetes/Service.yml
 
 [source, bash]
 ----
-oc new-app -l app=preference,version=v1 --name=preference-v1 --context-dir=preference/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > preference.yml
+oc new-app -l app=preference,version=v1 --name=preference-v1 --context-dir=preference/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' JAEGER_SERVICE_NAME=preference fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > preference.yml
 oc apply -f <(istioctl kube-inject -f preference.yml) -n tutorial
 oc delete svc/preference-v1 ; oc expose dc/preference-v1 --port=8080
 oc logs bc/preference-v1 -f
@@ -229,7 +229,7 @@ oc apply -f <(istioctl kube-inject -f ../../kubernetes/Deployment.yml) -n tutori
 oc create -f ../../kubernetes/Service.yml
 oc get pods -w
 
-or 
+or
 
 kubectl apply -f <(istioctl kube-inject -f ../../kubernetes/Deployment.yml) -n tutorial
 kubectl create -f ../../kubernetes/Service.yml

--- a/docs/2deploy-microservices.adoc
+++ b/docs/2deploy-microservices.adoc
@@ -75,7 +75,7 @@ kubectl create -f ../../kubernetes/Service.yml -n tutorial
 
 [source, bash]
 ----
-oc new-app --name=customer --context-dir=customer/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' JAEGER_SERVICE_NAME=customer fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > customer.yml
+oc new-app --name=customer --context-dir=customer/java/springboot --env=JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' --env=JAEGER_SERVICE_NAME=customer fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > customer.yml
 oc apply -f <(istioctl kube-inject -f customer.yml) -n tutorial
 oc delete svc/customer ; oc expose dc/customer --port=8080
 oc logs bc/customer -f
@@ -160,9 +160,9 @@ kubectl create -f ../../kubernetes/Service.yml
 
 [source, bash]
 ----
-oc new-app -l app=preference,version=v1 --name=preference-v1 --context-dir=preference/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' JAEGER_SERVICE_NAME=preference fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > preference.yml
+oc new-app -l app=preference,version=v1 --name=preference-v1 --context-dir=preference/java/springboot --env=JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' --env=JAEGER_SERVICE_NAME=preference fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > preference.yml
 oc apply -f <(istioctl kube-inject -f preference.yml) -n tutorial
-oc delete svc/preference-v1 ; oc expose dc/preference --port=8080
+oc delete svc/preference-v1 ; oc expose dc/preference-v1 --name=preference --port=8080
 oc logs bc/preference-v1 -f
 ----
 
@@ -240,7 +240,7 @@ kubectl get pods -w
 
 [source, bash]
 ----
-oc new-app -l app=recommendation,version=v1 --name=recommendation-v1 --context-dir=recommendation/java/vertx JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > recommendation.yml
+oc new-app -l app=recommendation,version=v1 --name=recommendation-v1 --context-dir=recommendation/java/vertx --env=JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > recommendation.yml
 oc apply -f <(istioctl kube-inject -f recommendation.yml) -n tutorial
 oc delete svc/recommendation-v1 ; oc create -f recommendation/kubernetes/Service.yml
 oc logs bc/recommendation-v1 -f

--- a/docs/2deploy-microservices.adoc
+++ b/docs/2deploy-microservices.adoc
@@ -75,7 +75,7 @@ kubectl create -f ../../kubernetes/Service.yml -n tutorial
 
 [source, bash]
 ----
-oc new-app --name=customer --context-dir=customer/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > customer.yml
+oc new-app --name=customer --context-dir=customer/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' JAEGER_SERVICE_NAME=customer fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > customer.yml
 oc apply -f <(istioctl kube-inject -f customer.yml) -n tutorial
 oc delete svc/customer ; oc expose dc/customer --port=8080
 oc logs bc/customer -f
@@ -162,7 +162,7 @@ kubectl create -f ../../kubernetes/Service.yml
 ----
 oc new-app -l app=preference,version=v1 --name=preference-v1 --context-dir=preference/java/springboot JAVA_OPTIONS='-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true' JAEGER_SERVICE_NAME=preference fabric8/s2i-java~https://github.com/redhat-developer-demos/istio-tutorial -o yaml  > preference.yml
 oc apply -f <(istioctl kube-inject -f preference.yml) -n tutorial
-oc delete svc/preference-v1 ; oc expose dc/preference-v1 --port=8080
+oc delete svc/preference-v1 ; oc expose dc/preference --port=8080
 oc logs bc/preference-v1 -f
 ----
 


### PR DESCRIPTION
Using OpenShift S2I build in order to deploy on OCP cluster, we must add `JAEGER_SERVICE_NAME` env to `preference` deployment.

Otherwise, embedded Tomcat is not able to start with missing service name for `tracingFilter`:

```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'tracer' defined in com.redhat.developer.demos.preference.PreferencesApplication: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.opentracing.Tracer]: Factory method 'tracer' threw exception; nested exception is java.lang.IllegalArgumentException: Service name must not be null or empty
```