### PR TITLE
feat(#92): Adds script to clean Istio resources

### DIFF
--- a/docs/4simple-routerules.adoc
+++ b/docs/4simple-routerules.adoc
@@ -212,3 +212,10 @@ Clean up
 istioctl delete -f istiofiles/virtual-service-recommendation-v1_and_v2_75_25.yml -n tutorial
 istioctl delete -f istiofiles/destination-rule-recommendation-v1-v2.yml -n tutorial
 ----
+
+or you can run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----

--- a/docs/5advanced-routerules.adoc
+++ b/docs/5advanced-routerules.adoc
@@ -1,5 +1,17 @@
 == Advanced Route Rules
 
+[IMPORTANT]
+.Before Start
+====
+You should have NO virtualservice nor destinationrule (in `tutorial` namespace) `istioctl get virtualservice` `istioctl get destinationrule` 
+if so run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
+====
+
 === Smart routing based on user-agent header (Canary Deployment)
 
 What is your user-agent?
@@ -90,6 +102,13 @@ istioctl delete -f istiofiles/destination-rule-recommendation-v1-v2.yml -n tutor
 istioctl delete -f istiofiles/virtual-service-mobile-recommendation-v2.yml -n tutorial
 ----
 
+or you can run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
+
 === Mirroring Traffic (Dark Launch)
 
 [source,bash]
@@ -108,7 +127,12 @@ istioctl get destinationrule
 ----
 
 You should have NO virtualservice nor destinationrule (in `tutorial` namespace) `istioctl get virtualservice` `istioctl get destinationrule` 
-if so `istioctl delete virtualservice virtualservicename -n tutorial` and `istioctl delete destinationrule destinationrulename -n tutorial`
+if so run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
 
 Make sure you are in the main directory of "istio-tutorial"
 
@@ -135,6 +159,13 @@ Clean up
 ----
 istioctl delete -f istiofiles/destination-rule-recommendation-v1-v2.yml -n tutorial
 istioctl delete -f istiofiles/virtual-service-recommendation-v1-mirror-v2.yml -n tutorial
+----
+
+or you can run:
+
+[source. bash]
+----
+./scripts/clean.sh
 ----
 
 === Access Control
@@ -339,4 +370,11 @@ Clean up
 istioctl delete -f istiofiles/rate_limit_rule.yml
 
 istioctl delete -f istiofiles/recommendation_rate_limit_handler.yml
+----
+
+or you can run:
+
+[source. bash]
+----
+./scripts/clean.sh
 ----

--- a/docs/6fault-injection.adoc
+++ b/docs/6fault-injection.adoc
@@ -2,6 +2,18 @@
 
 Apply some chaos engineering by throwing in some HTTP errors or network delays. Understanding failure scenarios is a critical aspect of microservices architecture (aka distributed computing)
 
+[IMPORTANT]
+.Before Start
+====
+You should have NO virtualservice nor destinationrule (in `tutorial` namespace) `istioctl get virtualservice` `istioctl get destinationrule` 
+if so run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
+====
+
 === HTTP Error 503
 
 By default, recommendation v1 and v2 are being randomly load-balanced as that is the default behavior in Kubernetes/OpenShift
@@ -275,4 +287,11 @@ Clean up, delete the timeout rule
 [source,bash]
 ----
 istioctl delete -f istiofiles/virtual-service-recommendation-timeout.yml -n tutorial
+----
+
+or you can run:
+
+[source. bash]
+----
+./scripts/clean.sh
 ----

--- a/docs/7circuit-breaker.adoc
+++ b/docs/7circuit-breaker.adoc
@@ -1,5 +1,17 @@
 == Circuit Breaker
 
+[IMPORTANT]
+.Before Start
+====
+You should have NO virtualservice nor destinationrule (in `tutorial` namespace) `istioctl get virtualservice` `istioctl get destinationrule` 
+if so run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
+====
+
 === Fail Fast with Max Connections and Max Pending Requests
 
 First, make sure to uncomment `router.get(&quot;/&quot;).handler(this::timeout);` in the RecommendationVerticle.java:
@@ -70,6 +82,13 @@ Clean up
 ----
 istioctl delete virtualservice recommendation -n tutorial
 istioctl delete -f istiofiles/destination-rule-recommendation_cb_policy_version_v2.yml -n tutorial
+----
+
+or you can run:
+
+[source. bash]
+----
+./scripts/clean.sh
 ----
 
 === Pool Ejection

--- a/docs/8egress.adoc
+++ b/docs/8egress.adoc
@@ -4,6 +4,18 @@ Let's see an example of using egress route by deploying a recommendation:v3 vers
 
 In this case, we are going to configure Istio to access http://now.httpbin.org from internal service (recommendation:v3).
 
+[IMPORTANT]
+.Before Start
+====
+You should have NO virtualservice nor destinationrule (in `tutorial` namespace) `istioctl get virtualservice` `istioctl get destinationrule` 
+if so run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
+====
+
 === Create recommendation:v3
 
 We can experiment with Egress service entry by making two changes to `RecommendationVerticle.java` like the following and creating a "v3" docker image.
@@ -148,7 +160,6 @@ exit
 ----
 
 
-
 Clean up
 
 [source,bash]
@@ -158,5 +169,9 @@ istioctl delete -f istiofiles/destination-rule-recommendation-v1-v2-v3.yml -n tu
 istioctl delete -f istiofiles/virtual-service-recommendation-v3.yml
 ----
 
+or you can run:
 
-
+[source. bash]
+----
+./scripts/clean.sh
+----

--- a/docs/advanced/virtualization.adoc
+++ b/docs/advanced/virtualization.adoc
@@ -1,6 +1,16 @@
 === Service Virtualization and Istio
 
-IMPORTANT: You should have NO `virtualservice` nor `destinationrule` in `tutorial` namespace, if so `istioctl delete virtualservice name -n tutorial` and `istioctl delete destinationrule name -n tutorial`
+[IMPORTANT]
+.Before Start
+====
+You should have NO virtualservice nor destinationrule (in `tutorial` namespace) `istioctl get virtualservice` `istioctl get destinationrule` 
+if so run:
+
+[source. bash]
+----
+./scripts/clean.sh
+----
+====
 
 We'll create version 2 of preferences service. 
 But in this case instead of communicating with recommendation service, we are going to communicate with a virtualized recommendation service.
@@ -166,6 +176,7 @@ Let's avoid this by just sending traffic that comes from preference v2 service t
 
 [source, bash]
 ----
+istioctl create -f istiofiles/destination-rule-recommendation-v1.yml -n tutorial
 istioctl create -f istiofiles/virtual-service-recommendation-virtualized.yml -n tutorial
 ----
 
@@ -186,6 +197,7 @@ Clean up
 
 [source,bash]
 ----
+istioctl delete -f istiofiles/destination-rule-recommendation-v1.yml -n tutorial
 istioctl delete -f istiofiles/virtual-service-recommendation-virtualized.yml -n tutorial
 oc delete all  -l app=preference,version=v2
 oc delete all  -l app=recommendation,version=virtualized

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+namespace=$1
+
+if [ -z "$namespace" ]; then
+    namespace="tutorial"
+fi
+
+contentvs=`istioctl get virtualservice -n "$namespace" 2>/dev/null` 
+
+if [ -z "$contentvs" ]; then
+    echo "No Virtual Services in $namespace namespace."
+else
+    contentvs=`awk 'NR>1' <<< "$contentvs"`
+
+    names=`awk -v namespace="$namespace" '{ {print $1} }' <<< "$contentvs"`
+
+    for name in "${names[@]}"
+    do
+        istioctl delete virtualservice "$name" -n "$namespace"
+    done
+    
+fi
+
+contentdr=`istioctl get destinationrule -n "$namespace" 2>/dev/null`
+
+if [ -z "$contentdr" ]; then
+    echo "No Destination Rule in $namespace namespace."
+else
+    contentdr=`awk 'NR>1' <<< "$contentdr"`
+
+    names=`awk -v namespace="$namespace" '{ {print $1} }' <<< "$contentdr"`
+
+    for name in "${names[@]}"
+    do
+        istioctl delete destinationrule "$name" -n "$namespace"
+    done
+    
+fi
+
+contentse=`istioctl get serviceentry -n "$namespace" 2>/dev/null`
+
+if [ -z "$contentse" ]; then
+    echo "No Service Entry in $namespace namespace."
+else
+    contentse=`awk 'NR>1' <<< "$contentse"`
+
+    names=`awk -v namespace="$namespace" '{ {print $1} }' <<< "$contentse"`
+
+    for name in "${names[@]}"
+    do
+        istioctl delete serviceentry "$name" -n "$namespace"
+    done
+    
+fi


### PR DESCRIPTION
I have created a `clean.sh` that cleans all istio resources created in the tutorial. I have updated the docs as well with hints about when to use it. Notice that in more complex clean up places where not all resources need to be cleaned up or for example that you also need to kill pods, I have not added a reference to the script because I think that could confuse the reader thinking that the script does everything.