### PR TITLE
Disable mTLS during initial setup

### DIFF
--- a/documentation/modules/ROOT/pages/1setup.adoc
+++ b/documentation/modules/ROOT/pages/1setup.adoc
@@ -199,7 +199,7 @@ Once operator is ready, create an installation for Istio
 ----
 #!/bin/bash
 oc project istio-operator
-cat <<EOF >>/tmp/istio-cr.yaml
+cat <<EOF >/tmp/istio-cr.yaml
 apiVersion: "istio.openshift.com/v1alpha1"
 kind: "Installation"
 metadata:
@@ -207,7 +207,7 @@ metadata:
 spec:
   deployment_type: origin
   istio:
-    authentication: true
+    authentication: false
     community: true
     prefix: maistra/
     version: 0.4.0


### PR DESCRIPTION
Disables mutual tls by default. Otherwise, the majority of the tutorial will not work as mTLS does not work with OpenShift's router which relies on pod IP address endpoints