### PR TITLE
Fix liveness and readinessprobe in keycloak deployment

### DIFF
--- a/keycloak/Deployment.yml
+++ b/keycloak/Deployment.yml
@@ -32,10 +32,10 @@ spec:
           httpGet:
             path: /auth/realms/master
             port: 8080
-            failureThreshold: 10
-            initialDelaySeconds: 30
+          failureThreshold: 10
+          initialDelaySeconds: 30
         livenessProbe:
           httpGet:
             path: /auth/realms/master
             port: 8080
-            initialDelaySeconds: 60
+          initialDelaySeconds: 60


### PR DESCRIPTION
Resolves #180 

After this patch is applied, the `keycloak/Deployment.yaml` resource can get deployed again.