### PR TITLE
No destinationrule defined at that stage

### DIFF
--- a/documentation/modules/ROOT/pages/5circuit-breaker.adoc
+++ b/documentation/modules/ROOT/pages/5circuit-breaker.adoc
@@ -76,7 +76,7 @@ curl localhost:8080/behave
 exit
 ----
 
-The application is back to random load-balancing between v1 and v2
+The application is back to round-robin load-balancing between v1 and v2
 
 [source,bash,subs="+macros,+attributes"]
 ----


### PR DESCRIPTION
There is no longer any destinationrule causing load-balancing to be random at this stage of the tutorial, so the default (round-robin) load-balancing is being used.