### PR TITLE
Update rate_limit_rule.yml

### DIFF
--- a/istiofiles/rate_limit_rule.yml
+++ b/istiofiles/rate_limit_rule.yml
@@ -1,13 +1,15 @@
 apiVersion: "config.istio.io/v1alpha2"
-kind: quota
+kind: instance
 metadata:
   name: requestcount
 spec:
-  dimensions:
-    source: source.labels["app"] | source.service | "unknown"
-    sourceVersion: source.labels["version"] | "unknown"
-    destination: destination.labels["app"] | destination.service | "unknown"
-    destinationVersion: destination.labels["version"] | "unknown"
+  compiledTemplate: quota
+  params:
+    dimensions:
+      source: source.labels["app"] | source.service | "unknown"
+      sourceVersion: source.labels["version"] | "unknown"
+      destination: destination.labels["app"] | destination.service | "unknown"
+      destinationVersion: destination.labels["version"] | "unknown"
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule


### PR DESCRIPTION
This yml throws the error "error: unable to recognize "istiofiles/rate_limit_rule.yml": no matches for config.istio.io/, Kind=quota".
The proposed change fixes this issue as the template for quota has changed - "https://istio.io/docs/reference/config/policy-and-telemetry/templates/quota/"