### PR TITLE
Update recommendation_rate_limit_handler.yml

### DIFF
--- a/istiofiles/recommendation_rate_limit_handler.yml
+++ b/istiofiles/recommendation_rate_limit_handler.yml
@@ -1,19 +1,21 @@
 apiVersion: "config.istio.io/v1alpha2"
-kind: memquota
+kind: handler
 metadata:
   name: handler
 spec:
-  quotas:
-  - name: requestcount.quota.istio-system
-    # default rate limit is 5000qps
-    maxAmount: 5000
-    validDuration: 1s
-    # The first matching override is applied.
-    # A requestcount instance is checked against override dimensions.
-    overrides:
-    - dimensions:
-        destination: recommendation
-        destinationVersion: v2
-        source: preference
-      maxAmount: 1
+  compiledAdapter: memquota
+  params:
+    quotas:
+    - name: requestcount.quota.istio-system
+      # default rate limit is 5000qps
+      maxAmount: 5000
       validDuration: 1s
+      # The first matching override is applied.
+      # A requestcount instance is checked against override dimensions.
+      overrides:
+      - dimensions:
+          destination: recommendation
+          destinationVersion: v2
+          source: preference
+        maxAmount: 1
+        validDuration: 1s


### PR DESCRIPTION
This yml throws the error "error: unable to recognize "istiofiles/recommendation_rate_limit_handler.yml": no matches for config.istio.io/, Kind=memquota".

The proposed change fixes this issue.. Per "https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1/#Handler" handlers have to used.. 

Tested this change on Istio 1.3.