### PR TITLE
Add commands to modify Openshift secure contexts

### DIFF
--- a/documentation/modules/ROOT/pages/1setup.adoc
+++ b/documentation/modules/ROOT/pages/1setup.adoc
@@ -116,22 +116,12 @@ kubectl config set-context $(kubectl config current-context) --namespace=istio-s
 
 IMPORTANT: `istio-demo.yaml` enables policy enforcement by default which is required in some sections of the tutorial. Please refer to https://istio.io/docs/tasks/policy-enforcement/enabling-policy/ if you are not using this file.
 
-If using OpenShift, secure contexts will need to be modified to allow ingress, egress, and Prometheus to run.
+If using OpenShift, modify security contexts to ensure that all pods start properly.
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ---
-oc adm policy add-scc-to-user anyuid -z istio-galley-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-galley-service-account -n istio-system^C
-oc adm policy add-scc-to-user anyuid -z istio-egressgateway-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-citadel-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-ingressgateway-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-cleanup-old-ca-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
-oc adm policy add-scc-to-user anyuid -z prometheus -n istio-system
+oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
 ---
 
 Wait for Istio's components to be ready

--- a/documentation/modules/ROOT/pages/1setup.adoc
+++ b/documentation/modules/ROOT/pages/1setup.adoc
@@ -116,6 +116,24 @@ kubectl config set-context $(kubectl config current-context) --namespace=istio-s
 
 IMPORTANT: `istio-demo.yaml` enables policy enforcement by default which is required in some sections of the tutorial. Please refer to https://istio.io/docs/tasks/policy-enforcement/enabling-policy/ if you are not using this file.
 
+If using OpenShift, secure contexts will need to be modified to allow ingress, egress, and Prmetheus to run.
+
+[.console-input]
+[source,bash,subs="attributes+,+macros"]
+---
+oc adm policy add-scc-to-user anyuid -z istio-galley-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-galley-service-account -n istio-system^C
+oc adm policy add-scc-to-user anyuid -z istio-egressgateway-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-citadel-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-ingressgateway-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-cleanup-old-ca-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z prometheus -n istio-system
+---
+
 Wait for Istio's components to be ready
 
 [.console-input]
@@ -149,7 +167,7 @@ Istio is supported in OpenShift by Red Hat OpenShift Service Mesh operator.
 
 To install it, you need to follow the instructions written in: https://docs.openshift.com/container-platform/4.3/service_mesh/service_mesh_install/preparing-ossm-installation.html
 
-It is important that after you finish with the installation, all the required pods are delpyed in `istio-system` namespace:
+It is important that after you finish with the installation, all the required pods are deployed in `istio-system` namespace:
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]

--- a/documentation/modules/ROOT/pages/1setup.adoc
+++ b/documentation/modules/ROOT/pages/1setup.adoc
@@ -116,7 +116,7 @@ kubectl config set-context $(kubectl config current-context) --namespace=istio-s
 
 IMPORTANT: `istio-demo.yaml` enables policy enforcement by default which is required in some sections of the tutorial. Please refer to https://istio.io/docs/tasks/policy-enforcement/enabling-policy/ if you are not using this file.
 
-If using OpenShift, secure contexts will need to be modified to allow ingress, egress, and Prmetheus to run.
+If using OpenShift, secure contexts will need to be modified to allow ingress, egress, and Prometheus to run.
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]

--- a/documentation/modules/ROOT/pages/1setup.adoc
+++ b/documentation/modules/ROOT/pages/1setup.adoc
@@ -157,6 +157,18 @@ Istio is supported in OpenShift by Red Hat OpenShift Service Mesh operator.
 
 To install it, you need to follow the instructions written in: https://docs.openshift.com/container-platform/4.3/service_mesh/service_mesh_install/preparing-ossm-installation.html
 
+--
+Minishift::
++
+---
+Modify security contexts to ensure that all pods start properly.
+
+[.console-input]
+[source,bash,subs="attributes+,+macros"]
+----
+oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
+----
+
 It is important that after you finish with the installation, all the required pods are deployed in `istio-system` namespace:
 
 [.console-input]


### PR DESCRIPTION
After deploying to Minishift 3.11, several of the pods refused to start, unable to write to their root fs. After some investigation, found that the SCC's needed to be changed. It was missing the command for Prometheus, so I added that.
